### PR TITLE
Change file name

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-env"]
-}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env"]
+}


### PR DESCRIPTION
Babel advises to use babel.config.js

> We recommend to use the babel.config.js format. Babel itself is using it.

[The reason for changing the name](https://babeljs.io/docs/en/config-files#6x-vs-7x-babelrc-loading)

I'm sorry for my English
